### PR TITLE
Add encodings for socket types and usize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+* Implement `CompactEncoding` for:
+  - `SocketAddrV4`
+  - `SocketAddrV6`
+  - `Ipv4Addr`
+  - `Ipv6Addr`
+* We also implement `CompactEncoding` for `usize` as a variable width integer.
+  The same as the JavaScript "uint" encoding
+
+### Changed
+
+### Removed
+
+
+
+
+<!-- next-url -->

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,7 @@
+pre-release-replacements = [
+  {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
+  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
+  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n### Added\n\n### Changed\n\n### Removed\n\n", exactly=1},
+  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/datrs/compact-encoding/compare/{{tag_name}}...HEAD", exactly=1},
+]

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,7 +87,7 @@ impl From<EncodingError> for std::io::Error {
             EncodingErrorKind::InvalidData => {
                 std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e}"))
             }
-            _ => std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")),
+            _ => std::io::Error::other(format!("{e}")),
         }
     }
 }


### PR DESCRIPTION
* Implement `CompactEncoding` for:
  - `SocketAddrV4`
  - `SocketAddrV6`
  - `Ipv4Addr`
  - `Ipv6Addr`
* We also implement `CompactEncoding` for `usize` as a variable width integer.
  The same as the JavaScript "uint" encoding