### PR TITLE
chore: Release compact-encoding version 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-encoding"
-version = "1.1.0"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 description = "A series of compact encoding schemes for building small and fast parsers and serializers"
 documentation = "https://docs.rs/compact-encoding"

--- a/src/fixedwidth.rs
+++ b/src/fixedwidth.rs
@@ -57,7 +57,7 @@ pub trait FixedWidthEncoding {
         Self: Sized;
 
     /// Get a uint in a form that encodes to a fixed width
-    fn as_fixed_width(&self) -> FixedWidthUint<Self> {
+    fn as_fixed_width(&self) -> FixedWidthUint<'_, Self> {
         FixedWidthUint(self)
     }
 }


### PR DESCRIPTION
Version bump for previous deployment